### PR TITLE
feat: API별 권한 설정 추가 및 수정

### DIFF
--- a/src/main/java/com/dangdang/check/common/config/SecurityConfig.java
+++ b/src/main/java/com/dangdang/check/common/config/SecurityConfig.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -59,6 +60,11 @@ public class SecurityConfig implements WebMvcConfigurer {
                                 "/api/employees",
                                 "/login", "/reissue")
                         .permitAll()
+                        .requestMatchers("/api/customers/**").hasAnyAuthority("GROOMER", "HEAD_GROOMER", "OWNER", "ADMIN")
+                        .requestMatchers(HttpMethod.POST, "/api/stores").hasAuthority("DEFAULT")
+                        .requestMatchers(HttpMethod.GET, "/api/stores/{storeId}").hasAnyAuthority("DEFAULT", "OWNER", "ADMIN")
+                        .requestMatchers(HttpMethod.GET, "/api/stores").hasAuthority("ADMIN")
+                        .requestMatchers(HttpMethod.PATCH, "/api/stores/**").hasAuthority("ADMIN")
                         .anyRequest().authenticated())
                 .sessionManagement(session ->
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))


### PR DESCRIPTION
- `/api/customers/**`: 고객 등록은 직원, 관리자만 가능하게 제한
- `POST /api/stores`: `DEFAULT` 권한을 가진 사용자만 신규 스토어 등록 가능하도록 제한
- `GET /api/stores/{storeId}`: 등록 사용자 혹은 점주, 관리자만 가능하도록 제한
- `GET /api/stores`: 목록은 관리자만 가능하도록 제한
- `PATCH /api/stores/**`: 수락, 거절 등 입점관련은 관리자만 가능하도록 제한